### PR TITLE
1 get all markets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,3 @@
 
 # Ignore SimpleCov coverage
 /coverage
-
-# Ignore RSpec examples.txt
-/spec/examples.txt

--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,6 @@ group :test do
   gem 'shoulda-matchers'
   gem 'simplecov'
 end
+
+# JSON API Serializer
+gem 'jsonapi-serializer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
     io-console (0.6.0)
     irb (1.6.4)
       reline (>= 0.3.0)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     launchy (2.5.2)
       addressable (~> 2.8)
     loofah (2.21.3)
@@ -219,6 +221,7 @@ DEPENDENCIES
   debug
   factory_bot_rails
   faker
+  jsonapi-serializer
   launchy
   pg (~> 1.1)
   pry

--- a/app/controllers/api/v0/markets_controller.rb
+++ b/app/controllers/api/v0/markets_controller.rb
@@ -1,0 +1,5 @@
+class Api::V0::MarketsController < ApplicationController
+  def index
+    render json: MarketSerializer.new(Market.all)
+  end
+end

--- a/app/serializers/market_serializer.rb
+++ b/app/serializers/market_serializer.rb
@@ -1,0 +1,8 @@
+class MarketSerializer
+  include JSONAPI::Serializer
+  attributes :id, :name, :street, :city, :county, :state, :zip, :lat, :lon
+
+  attribute :vendor_count do |market|
+    market.vendors.count
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,10 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+
+  namespace :api do
+    namespace :v0 do
+      resources :markets, only: [:index]
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,10 +65,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
-  # Filter failing tests
-  config.example_status_persistence_file_path = 'spec/examples.txt'
-  # run with rspec --only-failures and --next-failure
-
   # FactoryBot
   config.include FactoryBot::Syntax::Methods
 end

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+describe 'Markets API' do
+  it 'gets all markets' do
+    create_list(:market, 3)
+
+    get '/api/v0/markets'
+
+    expect(response).to be_successful
+
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data).to have_key(:data)
+
+    markets = data[:data]
+    expect(markets).to be_an(Array)
+    expect(markets.count).to eq(3)
+
+    markets.each do |market|
+      expect(market).to have_key(:id)
+      expect(market[:id]).to be_a(String)
+
+      expect(market).to have_key(:type)
+      expect(market[:type]).to eq("market")
+
+      expect(market).to have_key(:attributes)
+      expect(market[:attributes]).to be_a(Hash)
+
+      attributes = market[:attributes]
+
+      expect(attributes).to have_key(:id)
+      expect(attributes[:id]).to be_an(Integer)
+
+      expect(attributes).to have_key(:name)
+      expect(attributes[:name]).to be_a(String)
+
+      expect(attributes).to have_key(:street)
+      expect(attributes[:street]).to be_a(String)
+
+      expect(attributes).to have_key(:city)
+      expect(attributes[:city]).to be_a(String)
+
+      expect(attributes).to have_key(:county)
+      expect(attributes[:county]).to be_a(String)
+
+      expect(attributes).to have_key(:state)
+      expect(attributes[:state]).to be_a(String)
+
+      expect(attributes).to have_key(:zip)
+      expect(attributes[:zip]).to be_a(String)
+
+      expect(attributes).to have_key(:lat)
+      expect(attributes[:lat]).to be_a(String)
+
+      expect(attributes).to have_key(:lon)
+      expect(attributes[:lon]).to be_a(String)
+
+      expect(attributes).to have_key(:vendor_count)
+      expect(attributes[:vendor_count]).to be_an(Integer)
+    end
+  end
+
+  it 'returns the count of vendors for a market' do
+    market = create(:market)
+    vendors = create_list(:vendor, 3)
+
+    create(:market_vendor, market: market, vendor: vendors[0])
+    create(:market_vendor, market: market, vendor: vendors[1])
+
+    get '/api/v0/markets'
+
+    data = JSON.parse(response.body, symbolize_names: true)
+    market_data = data[:data].first
+
+    expect(market_data[:attributes][:vendor_count]).to eq(2)
+  end
+end


### PR DESCRIPTION
## Changes
- Routes
  - markets#index
- Markets Controller #index
  - MarketsSerialier with attributes and vendor_count 
  - test for markets request
- Add gem jsonapi-serializer
- Remove RSpec only-failures configuration

## Checklist
 - [x] tests created for new features
 - [x] all tests pass 100%

## Notes, questions, future refactors
- Does market serializer need `has_many :vendors`?
- Should `vendor_count` be a method in Market class?
- How to ignore file made with RSpec only failures configuration? or don't ignore?
- Market request spec test is really long...
