### PR TITLE
10 search markets

### DIFF
--- a/app/controllers/api/v0/markets_controller.rb
+++ b/app/controllers/api/v0/markets_controller.rb
@@ -9,9 +9,26 @@ class Api::V0::MarketsController < ApplicationController
     render json: MarketSerializer.new(@market)
   end
 
+  def search
+    if (params[:state].nil? && params[:city].present?) || search_params.empty?
+      render_invalid_search_response
+    else
+      render json: MarketSerializer.new(Market.search_all(search_params))
+    end
+  end
+
   private
 
   def find_market
     @market = Market.find(params[:id])
+  end
+
+  def search_params
+    params.permit(:state, :city, :name)
+  end
+
+  def render_invalid_search_response
+    message = "Invalid set of parameters. Please provide a valid set of parameters to perform a search with this endpoint."
+    render json: ErrorSerializer.serialize(message), status: 422
   end
 end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -9,4 +9,12 @@ class Market < ApplicationRecord
   def vendor_count
     vendors.count
   end
+
+  def self.search_all(params)
+    results = all
+    params.each do |key, value|
+      results = results.public_send("search_by_#{key}", value) if value.present?
+    end
+    results
+  end
 end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -2,6 +2,10 @@ class Market < ApplicationRecord
   has_many :market_vendors
   has_many :vendors, through: :market_vendors
 
+  scope :search_by_name, ->(name) { where('name ILIKE ?', "%#{name}%") }
+  scope :search_by_city, ->(city) { where('city ILIKE ?', "%#{city}%") }
+  scope :search_by_state, ->(state) { where('state ILIKE ?', "%#{state}%") }
+
   def vendor_count
     vendors.count
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v0 do
-      resources :markets, only: [:index, :show] do
+      resources :markets, only: [:index, :show, :search] do
         resources :vendors, only: [:index], controller: 'markets/vendors'
+        get 'search', on: :collection
       end
       resources :vendors, only: [:show, :create, :update, :destroy]
       resources :market_vendors, only: [:create]

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Market, type: :model do
     end
 
     describe 'search_by_name' do
-      it 'returns markets searched by name mark' do
-        expect(Market.search_by_name('mark')).to eq([@market1, @market2, @market3, @market4, @market5, @market6])
+      it 'returns markets searched by name farm' do
+        expect(Market.search_by_name('farm')).to eq([@market1, @market2, @market3, @market4])
       end
     end
 
@@ -26,6 +26,39 @@ RSpec.describe Market, type: :model do
     describe 'search_by_state' do
       it 'returns markets searched by state co' do
         expect(Market.search_by_state('co')).to eq([@market4, @market5, @market6])
+      end
+    end
+  end
+
+  describe 'class methods' do
+    before(:each) do
+      market_search_data
+    end
+
+    describe 'search_all' do
+      it 'returns markets searched by name farm' do
+        params = { 'name': 'farm' }
+        expect(Market.search_all(params)).to eq([@market1, @market2, @market3, @market4])
+      end
+
+      it 'returns markets searched by city ville' do
+        params = { 'city': 'ville' }
+        expect(Market.search_all(params)).to eq([@market2, @market4, @market5])
+      end
+
+      it 'returns markets searched by state co' do
+        params = { 'state': 'co' }
+        expect(Market.search_all(params)).to eq([@market4, @market5, @market6])
+      end
+
+      it 'returns markets searched by two fields' do
+        params = { 'city': 'ville', 'state': 'co' }
+        expect(Market.search_all(params)).to eq([@market4, @market5])
+      end
+
+      it 'returns markets searched by three fields' do
+        params = { 'name': 'farm', 'city': 'ville', 'state': 'co' }
+        expect(Market.search_all(params)).to eq([@market4])
       end
     end
   end

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -6,6 +6,30 @@ RSpec.describe Market, type: :model do
     it { should have_many(:vendors).through(:market_vendors) }
   end
 
+  describe 'scopes' do
+    before(:each) do
+      market_search_data
+    end
+
+    describe 'search_by_name' do
+      it 'returns markets searched by name mark' do
+        expect(Market.search_by_name('mark')).to eq([@market1, @market2, @market3, @market4, @market5, @market6])
+      end
+    end
+
+    describe 'search_by_city' do
+      it 'returns markets searched by city ville' do
+        expect(Market.search_by_city('ville')).to eq([@market2, @market4, @market5])
+      end
+    end
+
+    describe 'search_by_state' do
+      it 'returns markets searched by state co' do
+        expect(Market.search_by_state('co')).to eq([@market4, @market5, @market6])
+      end
+    end
+  end
+
   describe 'instance methods' do
     describe 'vendor_count' do
       it 'returns the count of vendors for a market' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,3 +76,19 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+
+def market_search_data
+  @market1 = create(:market, name: "Dallas Farmer's Market", city: 'Dallas', state: 'Texas')
+  @market2 = create(:market, name: "Lewisville Farmer's Market", city: 'Lewisville', state: 'Texas')
+  @market3 = create(:market, name: "Texas Farmer's Market at Mueller", city: 'Austin', state: 'Texas')
+  @market4 = create(:market, name: "CitySeed Downtown Farmer's Market", city: 'New Havenville', state: 'Conneticut')
+  @market5 = create(:market, name: 'Edgewater Public Market', city: 'Louisville', state: 'Colorado')
+  @market6 = create(:market, name: 'Rebel Marketplace', city: 'Aurora', state: 'Colorado')
+
+  # search by state = 'Co' = [@market4, @market5, @market6]
+  # search by city and state = 'ville' co = [@market4, @market5] - not 6 and 10
+  # search by name, city, and state = market ville colorado = [@market5]
+  # search by name and state = market tex = [@market1, @market2, @market3]
+  # search by name = farm = [@market1, @market2, @market3, @market4]
+  # no results search = tx = []
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,10 +85,10 @@ def market_search_data
   @market5 = create(:market, name: 'Edgewater Public Market', city: 'Louisville', state: 'Colorado')
   @market6 = create(:market, name: 'Rebel Marketplace', city: 'Aurora', state: 'Colorado')
 
-  # search by state = 'Co' = [@market4, @market5, @market6]
-  # search by city and state = 'ville' co = [@market4, @market5] - not 6 and 10
-  # search by name, city, and state = market ville colorado = [@market5]
-  # search by name and state = market tex = [@market1, @market2, @market3]
-  # search by name = farm = [@market1, @market2, @market3, @market4]
-  # no results search = tx = []
+  # search by { state=co } => [@market4, @market5, @market6]
+  # search by { city=ville&state=co } => [@market4, @market5]
+  # search by { name=farm&city=ville&state=co } => [@market5]
+  # search by { name=mark&state=tex } => [@market1, @market2, @market3]
+  # search by { name=farm } = [@market1, @market2, @market3, @market4]
+  # no results { state=tx } = []
 end

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -208,4 +208,302 @@ describe 'Markets API' do
       end
     end
   end
+
+  describe 'search Markets' do
+    describe 'happy path' do
+      it 'returns markets searched by state' do
+        market_search_data
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+
+        get '/api/v0/markets/search?state=co', headers: headers
+
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+
+        data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(data).to have_key(:data)
+
+        markets = data[:data]
+        expect(markets).to be_an(Array)
+        expect(markets.count).to eq(3)
+
+        markets.each do |market|
+          expect(market[:id]).to be_a(String)
+          expect(market[:type]).to eq("market")
+          expect(market[:attributes]).to be_a(Hash)
+
+          attributes = market[:attributes]
+          expect(attributes[:street]).to be_a(String)
+          expect(attributes[:county]).to be_a(String)
+          expect(attributes[:zip]).to be_a(String)
+          expect(attributes[:lat]).to be_a(String)
+          expect(attributes[:lon]).to be_a(String)
+          expect(attributes[:vendor_count]).to be_an(Integer)
+        end
+
+        market1 = markets[0]
+        market2 = markets[1]
+        market3 = markets[2]
+
+        expect(market1[:attributes][:name]).to eq(@market4.name)
+        expect(market1[:attributes][:city]).to eq(@market4.city)
+        expect(market1[:attributes][:state]).to eq(@market4.state)
+        expect(market2[:attributes][:name]).to eq(@market5.name)
+        expect(market2[:attributes][:city]).to eq(@market5.city)
+        expect(market2[:attributes][:state]).to eq(@market5.state)
+        expect(market3[:attributes][:name]).to eq(@market6.name)
+        expect(market3[:attributes][:city]).to eq(@market6.city)
+        expect(market3[:attributes][:state]).to eq(@market6.state)
+      end
+
+      it 'finds all market by state and city' do
+        market_search_data
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+
+        get '/api/v0/markets/search?city=ville&state=co', headers: headers
+
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+
+        data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(data).to have_key(:data)
+
+        markets = data[:data]
+        expect(markets).to be_an(Array)
+        expect(markets.count).to eq(2)
+
+        markets.each do |market|
+          expect(market[:id]).to be_a(String)
+          expect(market[:type]).to eq("market")
+          expect(market[:attributes]).to be_a(Hash)
+
+          attributes = market[:attributes]
+          expect(attributes[:street]).to be_a(String)
+          expect(attributes[:county]).to be_a(String)
+          expect(attributes[:zip]).to be_a(String)
+          expect(attributes[:lat]).to be_a(String)
+          expect(attributes[:lon]).to be_a(String)
+          expect(attributes[:vendor_count]).to be_an(Integer)
+        end
+
+        market1 = markets[0]
+        market2 = markets[1]
+
+        expect(market1[:attributes][:name]).to eq(@market4.name)
+        expect(market1[:attributes][:city]).to eq(@market4.city)
+        expect(market1[:attributes][:state]).to eq(@market4.state)
+        expect(market2[:attributes][:name]).to eq(@market5.name)
+        expect(market2[:attributes][:city]).to eq(@market5.city)
+        expect(market2[:attributes][:state]).to eq(@market5.state)
+      end
+
+      it 'finds all market by state, city, and name (result of 1 still returns in an array)' do
+        market_search_data
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+
+        get '/api/v0/markets/search?name=farm&city=ville&state=co', headers: headers
+
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+
+        data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(data).to have_key(:data)
+
+        markets = data[:data]
+        expect(markets).to be_an(Array)
+        expect(markets.count).to eq(1)
+
+        markets.each do |market|
+          expect(market[:id]).to be_a(String)
+          expect(market[:type]).to eq("market")
+          expect(market[:attributes]).to be_a(Hash)
+
+          attributes = market[:attributes]
+          expect(attributes[:street]).to be_a(String)
+          expect(attributes[:county]).to be_a(String)
+          expect(attributes[:zip]).to be_a(String)
+          expect(attributes[:lat]).to be_a(String)
+          expect(attributes[:lon]).to be_a(String)
+          expect(attributes[:vendor_count]).to be_an(Integer)
+        end
+
+        expect(markets[0][:attributes][:name]).to eq(@market4.name)
+        expect(markets[0][:attributes][:city]).to eq(@market4.city)
+        expect(markets[0][:attributes][:state]).to eq(@market4.state)
+      end
+
+      it 'finds all market by state and name' do
+        market_search_data
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+
+        get '/api/v0/markets/search?name=mark&state=tex', headers: headers
+
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+
+        data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(data).to have_key(:data)
+
+        markets = data[:data]
+        expect(markets).to be_an(Array)
+        expect(markets.count).to eq(3)
+
+        markets.each do |market|
+          expect(market[:id]).to be_a(String)
+          expect(market[:type]).to eq("market")
+          expect(market[:attributes]).to be_a(Hash)
+
+          attributes = market[:attributes]
+          expect(attributes[:street]).to be_a(String)
+          expect(attributes[:county]).to be_a(String)
+          expect(attributes[:zip]).to be_a(String)
+          expect(attributes[:lat]).to be_a(String)
+          expect(attributes[:lon]).to be_a(String)
+          expect(attributes[:vendor_count]).to be_an(Integer)
+        end
+
+        market1 = markets[0]
+        market2 = markets[1]
+        market3 = markets[2]
+
+        expect(market1[:attributes][:name]).to eq(@market1.name)
+        expect(market1[:attributes][:city]).to eq(@market1.city)
+        expect(market1[:attributes][:state]).to eq(@market1.state)
+        expect(market2[:attributes][:name]).to eq(@market2.name)
+        expect(market2[:attributes][:city]).to eq(@market2.city)
+        expect(market2[:attributes][:state]).to eq(@market2.state)
+        expect(market3[:attributes][:name]).to eq(@market3.name)
+        expect(market3[:attributes][:city]).to eq(@market3.city)
+        expect(market3[:attributes][:state]).to eq(@market3.state)
+      end
+
+      it 'finds all market by name' do
+        market_search_data
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+
+        get '/api/v0/markets/search?name=farm', headers: headers
+
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+
+        data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(data).to have_key(:data)
+
+        markets = data[:data]
+        expect(markets).to be_an(Array)
+        expect(markets.count).to eq(4)
+
+        markets.each do |market|
+          expect(market[:id]).to be_a(String)
+          expect(market[:type]).to eq("market")
+          expect(market[:attributes]).to be_a(Hash)
+
+          attributes = market[:attributes]
+          expect(attributes[:street]).to be_a(String)
+          expect(attributes[:county]).to be_a(String)
+          expect(attributes[:zip]).to be_a(String)
+          expect(attributes[:lat]).to be_a(String)
+          expect(attributes[:lon]).to be_a(String)
+          expect(attributes[:vendor_count]).to be_an(Integer)
+        end
+
+        market1 = markets[0]
+        market2 = markets[1]
+        market3 = markets[2]
+        market4 = markets[3]
+
+        expect(market1[:attributes][:name]).to eq(@market1.name)
+        expect(market1[:attributes][:city]).to eq(@market1.city)
+        expect(market1[:attributes][:state]).to eq(@market1.state)
+        expect(market2[:attributes][:name]).to eq(@market2.name)
+        expect(market2[:attributes][:city]).to eq(@market2.city)
+        expect(market2[:attributes][:state]).to eq(@market2.state)
+        expect(market3[:attributes][:name]).to eq(@market3.name)
+        expect(market3[:attributes][:city]).to eq(@market3.city)
+        expect(market3[:attributes][:state]).to eq(@market3.state)
+        expect(market4[:attributes][:name]).to eq(@market4.name)
+        expect(market4[:attributes][:city]).to eq(@market4.city)
+        expect(market4[:attributes][:state]).to eq(@market4.state)
+      end
+
+      it 'returns empty array if params are valid but no markets are returned' do
+        market_search_data
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+
+        get '/api/v0/markets/search?state=tx', headers: headers
+
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+
+        data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(data).to have_key(:data)
+
+        markets = data[:data]
+        expect(markets).to be_an(Array)
+        expect(markets.count).to eq(0)
+      end
+    end
+
+    describe 'sad path' do
+      it 'returns 422 error if only city parameter is passed' do
+        market_search_data
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+
+        get '/api/v0/markets/search?city=tx', headers: headers
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(422)
+
+        data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(data).to have_key(:errors)
+
+        errors = data[:errors]
+        expect(errors).to be_an(Array)
+        expect(errors.first[:detail]).to eq("Invalid set of parameters. Please provide a valid set of parameters to perform a search with this endpoint.")
+      end
+
+      it 'returns 422 error if city and name parameters are passed' do
+        market_search_data
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+
+        get '/api/v0/markets/search?city=error&name=422', headers: headers
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(422)
+
+        data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(data).to have_key(:errors)
+
+        errors = data[:errors]
+        expect(errors).to be_an(Array)
+        expect(errors.first[:detail]).to eq("Invalid set of parameters. Please provide a valid set of parameters to perform a search with this endpoint.")
+      end
+
+      it 'returns 422 error if no parameters are passed' do
+        market_search_data
+        headers = { 'CONTENT_TYPE' => 'application/json' }
+
+        get '/api/v0/markets/search?', headers: headers
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(422)
+
+        data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(data).to have_key(:errors)
+
+        errors = data[:errors]
+        expect(errors).to be_an(Array)
+        expect(errors.first[:detail]).to eq("Invalid set of parameters. Please provide a valid set of parameters to perform a search with this endpoint.")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes
- Add scopes to search Markets
- Add Market class method search_all
- Add market_search_data to rails_helper
  - Comment expected test results in market_search_data
- Add markets search route
- Markets controller search action with params and error handling


## Checklist
 - [x] tests created for new features
 - [x] all tests pass

## Notes, questions, future refactors
- The market request spec is too long, as well as all the other spec files - need to refactor!!
- Added search as an action rather than a specific controller. Both are non-ReSTful but is one more ReSTful than the other??
- learned how to use [public_send](https://apidock.com/ruby/Object/public_send)!
