### PR TITLE
11 get nearby cash dispensers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 
 # Ignore SimpleCov coverage
 /coverage
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ group :test do
   gem 'launchy'
   gem 'shoulda-matchers'
   gem 'simplecov'
+  gem 'webmock'
+  gem 'vcr'
 end
 
 # JSON API Serializer

--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,7 @@ end
 
 # JSON API Serializer
 gem 'jsonapi-serializer'
+
+# for API consumption
+gem 'faraday'
+gem 'figaro'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
       xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     date (3.3.3)
     debug (1.8.0)
@@ -105,6 +107,7 @@ GEM
       thor (>= 0.14.0, < 2)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -181,6 +184,7 @@ GEM
     regexp_parser (2.8.0)
     reline (0.3.3)
       io-console (~> 0.5)
+    rexml (3.2.5)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -211,6 +215,11 @@ GEM
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    vcr (6.1.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -240,6 +249,8 @@ DEPENDENCIES
   shoulda-matchers
   simplecov
   tzinfo-data
+  vcr
+  webmock
 
 RUBY VERSION
    ruby 3.1.1p18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,12 @@ GEM
       railties (>= 5.0.0)
     faker (3.2.0)
       i18n (>= 1.8.11, < 2)
+    faraday (2.7.4)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
+    figaro (1.2.0)
+      thor (>= 0.14.0, < 2)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.13.0)
@@ -192,6 +198,7 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.0)
+    ruby2_keywords (0.0.5)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     simplecov (0.22.0)
@@ -221,6 +228,8 @@ DEPENDENCIES
   debug
   factory_bot_rails
   faker
+  faraday
+  figaro
   jsonapi-serializer
   launchy
   pg (~> 1.1)

--- a/app/controllers/api/v0/markets/nearest_atms_controller.rb
+++ b/app/controllers/api/v0/markets/nearest_atms_controller.rb
@@ -1,0 +1,13 @@
+class Api::V0::Markets::NearestAtmsController < ApplicationController
+  def index
+    market = Market.find(market_params[:market_id])
+    atms = AtmFacade.new.find_nearby_atms(market.lat, market.lon)
+    render json: AtmSerializer.new(atms)
+  end
+
+  private
+
+  def market_params
+    params.permit(:market_id)
+  end
+end

--- a/app/facades/atm_facade.rb
+++ b/app/facades/atm_facade.rb
@@ -3,13 +3,7 @@ class AtmFacade
     json = service.nearby_atms(lat, lon)[:results]
 
     json.map do |atm_data|
-      {
-        name: atm_data[:poi][:name],
-        address: atm_data[:address][:freeformAddress],
-        lat: atm_data[:position][:lat],
-        lon: atm_data[:position][:lon],
-        distance: (atm_data[:dist] / 1609.344)
-      }
+      Atm.new(atm_data)
     end
   end
 

--- a/app/facades/atm_facade.rb
+++ b/app/facades/atm_facade.rb
@@ -1,0 +1,21 @@
+class AtmFacade
+  def find_nearby_atms(lat, lon)
+    json = service.nearby_atms(lat, lon)[:results]
+
+    json.map do |atm_data|
+      {
+        name: atm_data[:poi][:name],
+        address: atm_data[:address][:freeformAddress],
+        lat: atm_data[:position][:lat],
+        lon: atm_data[:position][:lon],
+        distance: (atm_data[:dist] / 1609.344)
+      }
+    end
+  end
+
+  private
+
+  def service
+    @_service ||= AtmService.new
+  end
+end

--- a/app/poros/atm.rb
+++ b/app/poros/atm.rb
@@ -1,15 +1,17 @@
 class Atm
-  attr_reader :name,
+  attr_reader :id,
+              :name,
               :address,
               :lat,
               :lon,
               :distance
 
   def initialize(data)
-    @name = data[:name]
-    @address = data[:address]
-    @lat = data[:lat]
-    @lon = data[:lon]
-    @distance = data[:distance] / 1609.344
+    @name = data[:poi][:name]
+    @address = data[:address][:freeformAddress]
+    @lat = data[:position][:lat]
+    @lon = data[:position][:lon]
+    @distance = data[:dist] / 1609.344
+    @id = nil
   end
 end

--- a/app/poros/atm.rb
+++ b/app/poros/atm.rb
@@ -1,0 +1,15 @@
+class Atm
+  attr_reader :name,
+              :address,
+              :lat,
+              :lon,
+              :distance
+
+  def initialize(data)
+    @name = data[:name]
+    @address = data[:address]
+    @lat = data[:lat]
+    @lon = data[:lon]
+    @distance = data[:distance] / 1609.344
+  end
+end

--- a/app/serializers/atm_serializer.rb
+++ b/app/serializers/atm_serializer.rb
@@ -1,0 +1,4 @@
+class AtmSerializer
+  include JSONAPI::Serializer
+  attributes :name, :address, :lat, :lon, :distance
+end

--- a/app/services/atm_service.rb
+++ b/app/services/atm_service.rb
@@ -1,0 +1,18 @@
+class AtmService
+  def nearby_atms(lat, lon)
+    get_url("/search/2/categorySearch/cash_dispensers.json?geobias=point:#{lat},#{lon}")
+  end
+
+  private
+
+  def get_url(url)
+    response = conn.get(url)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def conn
+    Faraday.new(url: 'https://api.tomtom.com') do |faraday|
+      faraday.params['key'] = ENV['TOMTOM_API_KEY']
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       resources :markets, only: [:index, :show, :search] do
         resources :vendors, only: [:index], controller: 'markets/vendors'
         get 'search', on: :collection
+        resources :nearest_atms, only: [:index], controller: 'markets/nearest_atms'
       end
       resources :vendors, only: [:show, :create, :update, :destroy]
       resources :market_vendors, only: [:create]

--- a/spec/facades/atm_facade_spec.rb
+++ b/spec/facades/atm_facade_spec.rb
@@ -11,20 +11,20 @@ RSpec.describe AtmService do
           expect(atm_data.count).to eq(10)
 
           first_atm = atm_data.first
-          expect(first_atm).to be_a(Hash)
-          expect(first_atm[:name]).to eq('ATM')
-          expect(first_atm[:address]).to eq('3902 Central Avenue Southeast, Albuquerque, NM 87108')
-          expect(first_atm[:lat]).to eq(35.079044)
-          expect(first_atm[:lon]).to eq(-106.60068)
-          expect(first_atm[:distance]).to eq(0.10548811068360774)
+          expect(first_atm).to be_an(Atm)
+          expect(first_atm.name).to eq('ATM')
+          expect(first_atm.address).to eq('3902 Central Avenue Southeast, Albuquerque, NM 87108')
+          expect(first_atm.lat).to eq(35.079044)
+          expect(first_atm.lon).to eq(-106.60068)
+          expect(first_atm.distance).to eq(0.10548811068360774)
 
           last_atm = atm_data.last
-          expect(last_atm).to be_a(Hash)
-          expect(last_atm[:name]).to eq('ATM at Efx')
-          expect(last_atm[:address]).to eq('4720 Central Avenue Southeast, Albuquerque, NM 87108')
-          expect(last_atm[:lat]).to eq(35.078207)
-          expect(last_atm[:lon]).to eq(-106.591563)
-          expect(last_atm[:distance]).to eq(0.504645272856518)
+          expect(last_atm).to be_an(Atm)
+          expect(last_atm.name).to eq('ATM at Efx')
+          expect(last_atm.address).to eq('4720 Central Avenue Southeast, Albuquerque, NM 87108')
+          expect(last_atm.lat).to eq(35.078207)
+          expect(last_atm.lon).to eq(-106.591563)
+          expect(last_atm.distance).to eq(0.504645272856518)
         end
       end
     end

--- a/spec/facades/atm_facade_spec.rb
+++ b/spec/facades/atm_facade_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe AtmService do
+  describe 'class methods' do
+    describe 'nearby_atms' do
+      it 'returns nearby atms data' do
+        VCR.use_cassette("nearby_atms") do
+          atm_data = AtmFacade.new.find_nearby_atms(35.077529, -106.600449)
+
+          expect(atm_data).to be_an(Array)
+          expect(atm_data.count).to eq(10)
+
+          first_atm = atm_data.first
+          expect(first_atm).to be_a(Hash)
+          expect(first_atm[:name]).to eq('ATM')
+          expect(first_atm[:address]).to eq('3902 Central Avenue Southeast, Albuquerque, NM 87108')
+          expect(first_atm[:lat]).to eq(35.079044)
+          expect(first_atm[:lon]).to eq(-106.60068)
+          expect(first_atm[:distance]).to eq(0.10548811068360774)
+
+          last_atm = atm_data.last
+          expect(last_atm).to be_a(Hash)
+          expect(last_atm[:name]).to eq('ATM at Efx')
+          expect(last_atm[:address]).to eq('4720 Central Avenue Southeast, Albuquerque, NM 87108')
+          expect(last_atm[:lat]).to eq(35.078207)
+          expect(last_atm[:lon]).to eq(-106.591563)
+          expect(last_atm[:distance]).to eq(0.504645272856518)
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/nearby_atms.yml
+++ b/spec/fixtures/vcr_cassettes/nearby_atms.yml
@@ -1,0 +1,106 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.tomtom.com/search/2/categorySearch/cash_dispensers.json?geobias=point:35.077529,-106.600449&key=9KegXXbYMo3eBTsjHqyRwXoj41Q1FUDb
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 May 2023 04:04:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Tracking-Id:
+      - e4953375-9d24-462f-9d34-8c62ad538d3d
+      Access-Control-Expose-Headers:
+      - Tracking-ID
+      X-Apigee.target-Latency:
+      - '15'
+      X-Envoy-Upstream-Service-Time:
+      - '30'
+      Server:
+      - tomtom
+      X-Tomtom-Processed-By:
+      - eastus
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"summary":{"query":"cash_dispensers","queryType":"NON_NEAR","queryTime":11,"numResults":10,"offset":0,"totalResults":96,"fuzzyLevel":1,"geoBias":{"lat":35.077529,"lon":-106.600449},"geobiasCountry":"US"},"results":[{"type":"POI","id":"zCkCLyNT3JUF8Kf5TsnodA","score":2.8319703478,"dist":169.766658,"info":"search:ta:840359000810929-US","poi":{"name":"ATM","categorySet":[{"id":7397}],"categories":["cash
+        dispenser"],"classifications":[{"code":"CASH_DISPENSER","names":[{"nameLocale":"en-US","name":"cash
+        dispenser"}]}]},"address":{"streetNumber":"3902","streetName":"Central Avenue
+        Southeast","municipalitySubdivision":"Nob Hill","municipality":"Albuquerque","countrySecondarySubdivision":"Bernalillo","countrySubdivision":"NM","countrySubdivisionName":"New
+        Mexico","postalCode":"87108","extendedPostalCode":"87108-1017","countryCode":"US","country":"United
+        States","countryCodeISO3":"USA","freeformAddress":"3902 Central Avenue Southeast,
+        Albuquerque, NM 87108","localName":"Albuquerque"},"position":{"lat":35.079044,"lon":-106.60068},"viewport":{"topLeftPoint":{"lat":35.07994,"lon":-106.60178},"btmRightPoint":{"lat":35.07814,"lon":-106.59958}},"entryPoints":[{"type":"main","position":{"lat":35.07929,"lon":-106.60064}}]},{"type":"POI","id":"9KWO-063BDvZD5huSf6FnQ","score":2.8319614309,"dist":232.781148,"info":"search:ta:840359000787908-US","poi":{"name":"ATM","categorySet":[{"id":7397}],"categories":["cash
+        dispenser"],"classifications":[{"code":"CASH_DISPENSER","names":[{"nameLocale":"en-US","name":"cash
+        dispenser"}]}]},"address":{"streetNumber":"4100","streetName":"Central Avenue
+        Southeast","municipalitySubdivision":"Nob Hill","municipality":"Albuquerque","countrySecondarySubdivision":"Bernalillo","countrySubdivision":"NM","countrySubdivisionName":"New
+        Mexico","postalCode":"87108","extendedPostalCode":"87108-1161","countryCode":"US","country":"United
+        States","countryCodeISO3":"USA","freeformAddress":"4100 Central Avenue Southeast,
+        Albuquerque, NM 87108","localName":"Albuquerque"},"position":{"lat":35.078804,"lon":-106.59842},"viewport":{"topLeftPoint":{"lat":35.0797,"lon":-106.59952},"btmRightPoint":{"lat":35.0779,"lon":-106.59732}},"entryPoints":[{"type":"main","position":{"lat":35.07904,"lon":-106.59838}}]},{"type":"POI","id":"jvwh5MLpuIqr_n3e77cgjQ","score":2.8319538253,"dist":275.775615,"info":"search:ta:840359000635604-US","poi":{"name":"Columbus
+        Data Services","categorySet":[{"id":7397}],"categories":["cash dispenser"],"classifications":[{"code":"CASH_DISPENSER","names":[{"nameLocale":"en-US","name":"cash
+        dispenser"}]}]},"address":{"streetNumber":"3801","streetName":"Central Avenue
+        Northeast","municipalitySubdivision":"Nob Hill","municipality":"Albuquerque","countrySecondarySubdivision":"Bernalillo","countrySubdivision":"NM","countrySubdivisionName":"New
+        Mexico","postalCode":"87108","countryCode":"US","country":"United States","countryCodeISO3":"USA","freeformAddress":"3801
+        Central Avenue Northeast, Albuquerque, NM 87108","localName":"Albuquerque"},"position":{"lat":35.079835,"lon":-106.601564},"viewport":{"topLeftPoint":{"lat":35.08073,"lon":-106.60266},"btmRightPoint":{"lat":35.07894,"lon":-106.60047}},"entryPoints":[{"type":"main","position":{"lat":35.07951,"lon":-106.60159}}]},{"type":"POI","id":"SP_XSCh6xu40i6etEc6HHA","score":2.8319404501,"dist":335.911598,"info":"search:ta:840359000656006-US","poi":{"name":"Lynk
+        Systems","categorySet":[{"id":7397}],"categories":["cash dispenser"],"classifications":[{"code":"CASH_DISPENSER","names":[{"nameLocale":"en-US","name":"cash
+        dispenser"}]}]},"address":{"streetNumber":"4212","streetName":"Coal Avenue
+        Southeast","municipalitySubdivision":"Nob Hill","municipality":"Albuquerque","countrySecondarySubdivision":"Bernalillo","countrySubdivision":"NM","countrySubdivisionName":"New
+        Mexico","postalCode":"87108","countryCode":"US","country":"United States","countryCodeISO3":"USA","freeformAddress":"4212
+        Coal Avenue Southeast, Albuquerque, NM 87108","localName":"Albuquerque"},"position":{"lat":35.075733,"lon":-106.597481},"viewport":{"topLeftPoint":{"lat":35.07663,"lon":-106.59858},"btmRightPoint":{"lat":35.07483,"lon":-106.59638}},"entryPoints":[{"type":"main","position":{"lat":35.07542,"lon":-106.59748}}]},{"type":"POI","id":"Pj7BcbBQugNCqA6-uC6Klw","score":2.8319244522,"dist":398.062843,"info":"search:ta:840359000772211-US","poi":{"name":"Prosperity
+        Bank","categorySet":[{"id":7397}],"categories":["cash dispenser"],"classifications":[{"code":"CASH_DISPENSER","names":[{"nameLocale":"en-US","name":"cash
+        dispenser"}]}]},"address":{"streetNumber":"4320","streetName":"Lead Avenue
+        Southeast","municipalitySubdivision":"Nob Hill","municipality":"Albuquerque","countrySecondarySubdivision":"Bernalillo","countrySubdivision":"NM","countrySubdivisionName":"New
+        Mexico","postalCode":"87108","extendedPostalCode":"87108-2725","countryCode":"US","country":"United
+        States","countryCodeISO3":"USA","freeformAddress":"4320 Lead Avenue Southeast,
+        Albuquerque, NM 87108","localName":"Albuquerque"},"position":{"lat":35.075622,"lon":-106.596747},"viewport":{"topLeftPoint":{"lat":35.07652,"lon":-106.59785},"btmRightPoint":{"lat":35.07472,"lon":-106.59565}},"entryPoints":[{"type":"main","position":{"lat":35.07572,"lon":-106.59669}}]},{"type":"POI","id":"mCM3tWRNT6a7kUNV2ZtVDA","score":2.8319074052,"dist":454.08628,"info":"search:ta:840359000280874-US","poi":{"name":"Cu
+        Anytime","categorySet":[{"id":7397}],"categories":["cash dispenser"],"classifications":[{"code":"CASH_DISPENSER","names":[{"nameLocale":"en-US","name":"cash
+        dispenser"}]}]},"address":{"streetNumber":"3500","streetName":"Central Avenue
+        Southeast","municipalitySubdivision":"Nob Hill","municipality":"Albuquerque","countrySecondarySubdivision":"Bernalillo","countrySubdivision":"NM","countrySubdivisionName":"New
+        Mexico","postalCode":"87106","extendedPostalCode":"87106-1434","countryCode":"US","country":"United
+        States","countryCodeISO3":"USA","freeformAddress":"3500 Central Avenue Southeast,
+        Albuquerque, NM 87106","localName":"Albuquerque"},"position":{"lat":35.079526,"lon":-106.604802},"viewport":{"topLeftPoint":{"lat":35.08043,"lon":-106.6059},"btmRightPoint":{"lat":35.07863,"lon":-106.6037}},"entryPoints":[{"type":"main","position":{"lat":35.07974,"lon":-106.60477}}]},{"type":"POI","id":"wMJ0WLjKpfLkOI2OHFT2aQ","score":2.831869902,"dist":558.313835,"info":"search:ta:840359000190272-US","poi":{"name":"Bank
+        of America Na","phone":"+1 844-401-8500","brands":[{"name":"Bank of America"}],"categorySet":[{"id":7397}],"url":"locators.bankofamerica.com/nm/albuquerque/financial-","categories":["cash
+        dispenser"],"classifications":[{"code":"CASH_DISPENSER","names":[{"nameLocale":"en-US","name":"cash
+        dispenser"}]}]},"address":{"streetNumber":"4401","streetName":"Central Avenue
+        Northeast","municipalitySubdivision":"Highland Business","municipality":"Albuquerque","countrySecondarySubdivision":"Bernalillo","countrySubdivision":"NM","countrySubdivisionName":"New
+        Mexico","postalCode":"87108","extendedPostalCode":"87108-1209","countryCode":"US","country":"United
+        States","countryCodeISO3":"USA","freeformAddress":"4401 Central Avenue Northeast,
+        Albuquerque, NM 87108","localName":"Albuquerque"},"position":{"lat":35.079896,"lon":-106.595038},"viewport":{"topLeftPoint":{"lat":35.08097,"lon":-106.59635},"btmRightPoint":{"lat":35.07882,"lon":-106.59372}},"entryPoints":[{"type":"main","position":{"lat":35.07883,"lon":-106.59523}},{"type":"main","position":{"lat":35.07883,"lon":-106.59521}}]},{"type":"POI","id":"E2UU01qb6o_7iFZVEyLXag","score":2.831845774,"dist":616.407072,"info":"search:ta:840359000644797-US","poi":{"name":"Prosperity
+        Bank","categorySet":[{"id":7397}],"categories":["cash dispenser"],"classifications":[{"code":"CASH_DISPENSER","names":[{"nameLocale":"en-US","name":"cash
+        dispenser"}]}]},"address":{"streetNumber":"4420","streetName":"Zuni Road Southeast","municipalitySubdivision":"Parkland
+        Hills","municipality":"Albuquerque","countrySecondarySubdivision":"Bernalillo","countrySubdivision":"NM","countrySubdivisionName":"New
+        Mexico","postalCode":"87108","extendedPostalCode":"87108-2844","countryCode":"US","country":"United
+        States","countryCodeISO3":"USA","freeformAddress":"4420 Zuni Road Southeast,
+        Albuquerque, NM 87108","localName":"Albuquerque"},"position":{"lat":35.074343,"lon":-106.594906},"viewport":{"topLeftPoint":{"lat":35.07524,"lon":-106.596},"btmRightPoint":{"lat":35.07344,"lon":-106.59381}},"entryPoints":[{"type":"main","position":{"lat":35.07457,"lon":-106.59478}}]},{"type":"POI","id":"Q8j_aPovM1ZDAMXlY8Y9iQ","score":2.8317566055,"dist":794.363815,"info":"search:ta:840359000656657-US","poi":{"name":"Lynk
+        Systems","categorySet":[{"id":7397}],"categories":["cash dispenser"],"classifications":[{"code":"CASH_DISPENSER","names":[{"nameLocale":"en-US","name":"cash
+        dispenser"}]}]},"address":{"streetNumber":"3222","streetName":"Central Avenue
+        Southeast","municipalitySubdivision":"Nob Hill","municipality":"Albuquerque","countrySecondarySubdivision":"Bernalillo","countrySubdivision":"NM","countrySubdivisionName":"New
+        Mexico","postalCode":"87106","extendedPostalCode":"87106-1442","countryCode":"US","country":"United
+        States","countryCodeISO3":"USA","freeformAddress":"3222 Central Avenue Southeast,
+        Albuquerque, NM 87106","localName":"Albuquerque"},"position":{"lat":35.079961,"lon":-106.608657},"viewport":{"topLeftPoint":{"lat":35.08086,"lon":-106.60976},"btmRightPoint":{"lat":35.07906,"lon":-106.60756}},"entryPoints":[{"type":"main","position":{"lat":35.08028,"lon":-106.60859}}]},{"type":"POI","id":"yO8BILTn614HA4db8suZAw","score":2.8317463773,"dist":812.147842,"info":"search:ta:840359000538243-US","poi":{"name":"ATM
+        at Efx","categorySet":[{"id":7397}],"categories":["cash dispenser"],"classifications":[{"code":"CASH_DISPENSER","names":[{"nameLocale":"en-US","name":"cash
+        dispenser"}]}]},"address":{"streetNumber":"4720","streetName":"Central Avenue
+        Southeast","municipalitySubdivision":"Highland Business","municipality":"Albuquerque","countrySecondarySubdivision":"Bernalillo","countrySubdivision":"NM","countrySubdivisionName":"New
+        Mexico","postalCode":"87108","extendedPostalCode":"87108-1225","countryCode":"US","country":"United
+        States","countryCodeISO3":"USA","freeformAddress":"4720 Central Avenue Southeast,
+        Albuquerque, NM 87108","localName":"Albuquerque"},"position":{"lat":35.078207,"lon":-106.591563},"viewport":{"topLeftPoint":{"lat":35.07911,"lon":-106.59266},"btmRightPoint":{"lat":35.07731,"lon":-106.59046}},"entryPoints":[{"type":"main","position":{"lat":35.07829,"lon":-106.59153}}]}]}'
+  recorded_at: Fri, 19 May 2023 04:04:53 GMT
+recorded_with: VCR 6.1.0

--- a/spec/poros/atm_spec.rb
+++ b/spec/poros/atm_spec.rb
@@ -4,38 +4,38 @@ RSpec.describe Atm do
   describe 'initialize' do
     it 'exists and has attributes' do
       data = {
-        "name": 'ATM',
-        "address": '3902 Central Avenue Southeast, Albuquerque, NM 87108',
-        "lat": 35.07904,
-        "lon": -106.60068,
-        "distance": 169.766658
+        poi: { name: 'ATM' },
+        address: { freeformAddress: '3902 Central Avenue Southeast, Albuquerque, NM 87108' },
+        position: { "lat": 35.07904, "lon": -106.60068 },
+        dist: 169.766658
       }
       atm = Atm.new(data)
 
       expect(atm).to be_an(Atm)
-      expect(atm.name).to eq(data[:name])
-      expect(atm.address).to eq(data[:address])
-      expect(atm.lat).to eq(data[:lat])
-      expect(atm.lon).to eq(data[:lon])
+      expect(atm.id).to eq(nil)
+      expect(atm.name).to eq(data[:poi][:name])
+      expect(atm.address).to eq(data[:address][:freeformAddress])
+      expect(atm.lat).to eq(data[:position][:lat])
+      expect(atm.lon).to eq(data[:position][:lon])
       expect(atm.distance).to eq(0.10548811068360774)
     end
 
     it 'can initalize another object' do
       data = {
-        "name": 'ATM at Efx',
-        "address": '4720 Central Avenue Southeast, Albuquerque, NM 87108',
-        "lat": 35.078207,
-        "lon": -106.591563,
-        "distance": 812.147842
+        poi: { name: 'ATM at Efx' },
+        address: { freeformAddress: '4720 Central Avenue Southeast, Albuquerque, NM 87108' },
+        position: { "lat": 35.078207, "lon": -106.591563 },
+        dist: 812.147842
       }
       atm = Atm.new(data)
 
       expect(atm).to be_an(Atm)
-      expect(atm.name).to eq(data[:name])
-      expect(atm.address).to eq(data[:address])
-      expect(atm.lat).to eq(data[:lat])
-      expect(atm.lon).to eq(data[:lon])
+      expect(atm.name).to eq(data[:poi][:name])
+      expect(atm.address).to eq(data[:address][:freeformAddress])
+      expect(atm.lat).to eq(data[:position][:lat])
+      expect(atm.lon).to eq(data[:position][:lon])
       expect(atm.distance).to eq(0.504645272856518)
+      expect(atm.id).to eq(nil)
     end
   end
 end

--- a/spec/poros/atm_spec.rb
+++ b/spec/poros/atm_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Atm do
+  describe 'initialize' do
+    it 'exists and has attributes' do
+      data = {
+        "name": 'ATM',
+        "address": '3902 Central Avenue Southeast, Albuquerque, NM 87108',
+        "lat": 35.07904,
+        "lon": -106.60068,
+        "distance": 169.766658
+      }
+      atm = Atm.new(data)
+
+      expect(atm).to be_an(Atm)
+      expect(atm.name).to eq(data[:name])
+      expect(atm.address).to eq(data[:address])
+      expect(atm.lat).to eq(data[:lat])
+      expect(atm.lon).to eq(data[:lon])
+      expect(atm.distance).to eq(0.10548811068360774)
+    end
+
+    it 'can initalize another object' do
+      data = {
+        "name": 'ATM at Efx',
+        "address": '4720 Central Avenue Southeast, Albuquerque, NM 87108',
+        "lat": 35.078207,
+        "lon": -106.591563,
+        "distance": 812.147842
+      }
+      atm = Atm.new(data)
+
+      expect(atm).to be_an(Atm)
+      expect(atm.name).to eq(data[:name])
+      expect(atm.address).to eq(data[:address])
+      expect(atm.lat).to eq(data[:lat])
+      expect(atm.lon).to eq(data[:lon])
+      expect(atm.distance).to eq(0.504645272856518)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,6 +77,12 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
+# VCR
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+end
+
 def market_search_data
   @market1 = create(:market, name: "Dallas Farmer's Market", city: 'Dallas', state: 'Texas')
   @market2 = create(:market, name: "Lewisville Farmer's Market", city: 'Lewisville', state: 'Texas')

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -506,4 +506,65 @@ describe 'Markets API' do
       end
     end
   end
+
+  describe 'get atms nearby market' do
+    describe 'happy path' do
+      it 'returns atms in order by nearest to the market' do
+        VCR.use_cassette("nearby_atms") do
+          market = create(:market, lat: '35.077529', lon: '-106.600449')
+
+          get "/api/v0/markets/#{market.id}/nearest_atms"
+
+          expect(response).to be_successful
+          expect(response.status).to eq(200)
+
+          atm_data = JSON.parse(response.body, symbolize_names: true)
+
+          expect(atm_data).to have_key(:data)
+          expect(atm_data[:data]).to be_an(Array)
+
+          atms = atm_data[:data]
+
+          atms.each do |atm|
+            expect(atm).to have_key(:id)
+            expect(atm[:id]).to be_nil
+
+            expect(atm).to have_key(:type)
+            expect(atm[:type]).to eq('atm')
+
+            expect(atm).to have_key(:attributes)
+            expect(atm[:attributes]).to be_a(Hash)
+
+            attributes = atm[:attributes]
+
+            expect(attributes[:name]).to be_a(String)
+            expect(attributes[:address]).to be_a(String)
+            expect(attributes[:lat]).to be_a(Float)
+            expect(attributes[:lon]).to be_a(Float)
+            expect(attributes[:distance]).to be_a(Float)
+          end
+        end
+      end
+    end
+
+    describe 'sad path' do
+      it 'returns 404 error if market id is invalid' do
+        false_id = 1234567890
+
+        get "/api/v0/markets/#{false_id}/nearest_atms"
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(404)
+
+        error = JSON.parse(response.body, symbolize_names: true)
+
+        expect(error).to have_key(:errors)
+        expect(error[:errors]).to be_an Array
+        expect(error[:errors].first).to be_a Hash
+        expect(error[:errors].first).to have_key(:detail)
+        expect(error[:errors].first[:detail]).to be_a String
+        expect(error[:errors].first[:detail]).to eq("Couldn't find Market with 'id'=#{false_id}")
+      end
+    end
+  end
 end

--- a/spec/services/atm_service_spec.rb
+++ b/spec/services/atm_service_spec.rb
@@ -4,28 +4,51 @@ RSpec.describe AtmService do
   describe 'class methods' do
     describe 'nearby_atms' do
       it 'returns nearby atms' do
-        search = AtmService.new.nearby_atms(35.077529, -106.600449)
-        
-        expect(search).to be_a(Hash)
-        expect(search[:results]).to be_an Array
-        atm_data = search[:results].first
+        VCR.use_cassette("nearby_atms") do
+          search = AtmService.new.nearby_atms(35.077529, -106.600449)
 
-        expect(atm_data).to have_key(:poi)
-        expect(atm_data[:poi]).to have_key(:name)
-        expect(atm_data[:poi][:name]).to eq('ATM')
+          expect(search).to be_a(Hash)
+          expect(search[:results]).to be_an Array
+          expect(search[:results].count).to eq(10)
 
-        expect(atm_data).to have_key(:address)
-        expect(atm_data[:address]).to have_key(:freeformAddress)
-        expect(atm_data[:address][:freeformAddress]).to eq('3902 Central Avenue Southeast, Albuquerque, NM 87108')
+          first_atm_data = search[:results].first
 
-        expect(atm_data).to have_key(:position)
-        expect(atm_data[:position]).to have_key(:lat)
-        expect(atm_data[:position][:lat]).to eq(35.079044)
-        expect(atm_data[:position]).to have_key(:lon)
-        expect(atm_data[:position][:lon]).to eq(-106.60068)
+          expect(first_atm_data).to have_key(:poi)
+          expect(first_atm_data[:poi]).to have_key(:name)
+          expect(first_atm_data[:poi][:name]).to eq('ATM')
 
-        expect(atm_data).to have_key(:dist)
-        expect(atm_data[:dist]).to eq(169.766658)
+          expect(first_atm_data).to have_key(:address)
+          expect(first_atm_data[:address]).to have_key(:freeformAddress)
+          expect(first_atm_data[:address][:freeformAddress]).to eq('3902 Central Avenue Southeast, Albuquerque, NM 87108')
+
+          expect(first_atm_data).to have_key(:position)
+          expect(first_atm_data[:position]).to have_key(:lat)
+          expect(first_atm_data[:position][:lat]).to eq(35.079044)
+          expect(first_atm_data[:position]).to have_key(:lon)
+          expect(first_atm_data[:position][:lon]).to eq(-106.60068)
+
+          expect(first_atm_data).to have_key(:dist)
+          expect(first_atm_data[:dist]).to eq(169.766658)
+
+          last_atm_data = search[:results].last
+
+          expect(last_atm_data).to have_key(:poi)
+          expect(last_atm_data[:poi]).to have_key(:name)
+          expect(last_atm_data[:poi][:name]).to eq('ATM at Efx')
+
+          expect(last_atm_data).to have_key(:address)
+          expect(last_atm_data[:address]).to have_key(:freeformAddress)
+          expect(last_atm_data[:address][:freeformAddress]).to eq('4720 Central Avenue Southeast, Albuquerque, NM 87108')
+
+          expect(last_atm_data).to have_key(:position)
+          expect(last_atm_data[:position]).to have_key(:lat)
+          expect(last_atm_data[:position][:lat]).to eq(35.078207)
+          expect(last_atm_data[:position]).to have_key(:lon)
+          expect(last_atm_data[:position][:lon]).to eq(-106.591563)
+
+          expect(last_atm_data).to have_key(:dist)
+          expect(last_atm_data[:dist]).to eq(812.147842)
+        end
       end
     end
   end

--- a/spec/services/atm_service_spec.rb
+++ b/spec/services/atm_service_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe AtmService do
+  describe 'class methods' do
+    describe 'nearby_atms' do
+      it 'returns nearby atms' do
+        search = AtmService.new.nearby_atms(35.077529, -106.600449)
+        
+        expect(search).to be_a(Hash)
+        expect(search[:results]).to be_an Array
+        atm_data = search[:results].first
+
+        expect(atm_data).to have_key(:poi)
+        expect(atm_data[:poi]).to have_key(:name)
+        expect(atm_data[:poi][:name]).to eq('ATM')
+
+        expect(atm_data).to have_key(:address)
+        expect(atm_data[:address]).to have_key(:freeformAddress)
+        expect(atm_data[:address][:freeformAddress]).to eq('3902 Central Avenue Southeast, Albuquerque, NM 87108')
+
+        expect(atm_data).to have_key(:position)
+        expect(atm_data[:position]).to have_key(:lat)
+        expect(atm_data[:position][:lat]).to eq(35.079044)
+        expect(atm_data[:position]).to have_key(:lon)
+        expect(atm_data[:position][:lon]).to eq(-106.60068)
+
+        expect(atm_data).to have_key(:dist)
+        expect(atm_data[:dist]).to eq(169.766658)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,3 +92,6 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
 end
+
+# Webmock
+require 'webmock/rspec'


### PR DESCRIPTION
## Changes
- Add gems faraday and figaro (install and add TomTom api key)
- - Add gems webmock and vcr with configuration and fixtures
- Feat/Test: AtmService to consume TomTom API for atms
  - add VCR cassette and add tests for last atm in search for AtmService
- Feat/Test: AtmFacade with find_nearby_atms
- Create and test Atm PORO (refactor x2)
- Add markets nearest atms route
- Test: for get nearest atms by a market request
- Create Markets NearestAtms controller with index action


## Checklist
 - [x] tests created for new features
 - [x] all tests pass

## Notes, questions, future refactors
- one test fails on Postman Collection test, but passes on specific request test...
- make last refactor for request specs bc tooooooo long! 
